### PR TITLE
Refactor schemas

### DIFF
--- a/openapi/commons/components/schemas/Note.yaml
+++ b/openapi/commons/components/schemas/Note.yaml
@@ -14,5 +14,3 @@ allOf:
         enum:
           - pathology
           - phone_call
-# required:
-#   - text


### PR DESCRIPTION
This PR will look into the following improvements:

- [ ] Conciliate detailed schema that represent DB content and schema used as input/output for an endpoint (e.g. does not need `createdBy`).
- [ ] For a given schema, different set of its properties may be required for different endpoints. The solution is likely locally (re)define the `required` properties.
- [ ] It could be useful to customize the properties example depending on the endpoint called. For example, have a Note example that includes a SSN for the SSN annotator.
- [ ] Math annotators will just returns an Annotator. Do we need a discriminator for different type of schemas? May be useful for array of different type of annotator. 
- [ ] Replace the Note schema by a more standard one (e.g. from FHIR?)